### PR TITLE
Fixed issues that were blocking support for Python 3 and Django 1.7.

### DIFF
--- a/redactor/utils.py
+++ b/redactor/utils.py
@@ -1,7 +1,10 @@
-from django.utils import simplejson as json
+import json
 
 from django.utils.functional import Promise
-from django.utils.encoding import force_unicode
+try:
+    from django.utils.encoding import force_unicode
+except ImportError:
+    from django.utils.encoding import force_text as force_unicode
 
 class LazyEncoder(json.JSONEncoder):
     """Encodes django's lazy i18n strings.

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -1,11 +1,20 @@
-from urlparse import urljoin
+import sys
+
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 from django.conf import settings
 from django.forms import Media, Textarea
 from django.utils.safestring import mark_safe
-from django.utils import simplejson as json
+import json
 
 from .utils import LazyEncoder
+
+# Python 3 does not have basestring - https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit
+if sys.version_info > (3, 0):
+    basestring = str
 
 
 class RedactorEditor(Textarea):


### PR DESCRIPTION
utils.py
- As Django as of 1.5+ supports Python 2.5 (which includes json) this should be removed and Django 1.7 does not have simplejson included.
- force_unicode is only available to Python 2 environments. Includes force_text instead if Python 3 but uses an alias to prevent code branch logic where it's used.

widgets.py
- urlpase is part of the urllib.parse library in Python 3.
- Changed simplejson import to json
- Alias basestring to point to str if Python 3. Doing this here prevents branching logic where it's used.
